### PR TITLE
Forward exceptions instead of logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessypy"
-version = "0.2.0"
+version = "0.1.3"
 authors = [
 	{ name="PimDoos" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessypy"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
 	{ name="PimDoos" },
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sessypy
-version = 0.2.0
+version = 0.1.3
 author = PimDoos
 url = https://github.com/PimDoos/sessypy
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sessypy
-version = 0.1.2
+version = 0.2.0
 author = PimDoos
 url = https://github.com/PimDoos/sessypy
 long_description = file: README.md

--- a/src/sessypy/api.py
+++ b/src/sessypy/api.py
@@ -30,18 +30,18 @@ class SessyApi:
         
         except ClientConnectionError as e:
             _LOGGER.debug(f"{method} request to {url} raised a connection error: {e}")
-            raise SessyConnectionException
+            raise SessyConnectionException from e
         
         except ContentTypeError as e:
             _LOGGER.debug(f"{method} request to {url} returned content of an unexpected type: {e.message}")
-            raise SessyNotSupportedException
+            raise SessyNotSupportedException from e
         
         except ClientResponseError as e:
             _LOGGER.debug(f"{method} request to {url} returned an error response code: {e.status} {e.message}")
             if e.status == 401:
-                raise SessyLoginException
+                raise SessyLoginException from e
             else:
-                raise SessyNotSupportedException
+                raise SessyNotSupportedException from e
 
     def _command_url(self, command: SessyApiCommand):
         return f"http://{self.host}/{command.value}"

--- a/src/sessypy/devices.py
+++ b/src/sessypy/devices.py
@@ -113,10 +113,12 @@ async def get_sessy_device(host: str, username: str, password: str) -> SessyDevi
             return device_profile[0](api)
         except SessyConnectionException:
             _LOGGER.debug(f"Skipping device profile {device_profile[0]} for {host}: Connection exception")
-            pass
+
         except SessyNotSupportedException:
             _LOGGER.debug(f"Skipping device profile {device_profile[0]} for {host}: Not supported")
-            pass
+
 
     await api.close()
-    return None
+    
+    # Device does not match any known device profiles, so it is not supported
+    raise SessyNotSupportedException


### PR DESCRIPTION
Potentially breaking change: Device discovery now raises `SessyNotSupportedException` when no device profile matches