### PR TITLE
Add model to devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sessypy"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
 	{ name="PimDoos" },
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sessypy
-version = 0.2.4
+version = 0.2.5
 author = PimDoos
 url = https://github.com/PimDoos/sessypy
 long_description = file: README.md

--- a/src/sessypy/devices.py
+++ b/src/sessypy/devices.py
@@ -32,6 +32,11 @@ class SessyDevice():
     def api(self) -> SessyApi:
         return self._api
 
+    @property
+    def model(self) -> str:
+        """Model of the device"""
+        return NotImplementedError
+
     async def get_ota_status(self):
         return await self.api.get(SessyApiCommand.OTA_STATUS)
     
@@ -71,6 +76,10 @@ class SessyDevice():
         await self.api.close()
     
 class SessyBattery(SessyDevice):
+    @property
+    def model(self):
+        return "WiFi Dongle"
+    
     async def get_dynamic_schedule(self):
         return await self.api.get(SessyApiCommand.DYNAMIC_SCHEDULE)
     
@@ -103,6 +112,10 @@ class SessyMeter(SessyDevice):
         return await self.api.get(SessyApiCommand.METER_STATUS)
 
 class SessyP1Meter(SessyMeter):
+    @property
+    def model(self):
+        return "P1 Meter"
+    
     async def get_p1_details(self):
         return await self.api.get(SessyApiCommand.P1_DETAILS)
     
@@ -110,6 +123,10 @@ class SessyP1Meter(SessyMeter):
         return await self.api.get(SessyApiCommand.MODBUS_DETAILS)
 
 class SessyCTMeter(SessyMeter):
+    @property
+    def model(self):
+        return "CT Meter"
+    
     async def get_ct_details(self):
         return await self.api.get(SessyApiCommand.CT_DETAILS)
     


### PR DESCRIPTION
Adds model string property to devices. This describes the model of the device offering the API.
- Cxxx: Sessy CT Meter
- Dxxx: Sessy WiFi Dongle
- Pxxx: Sessy P1 Meter

In Home Assistant, this will be used to generate the Device Name. 